### PR TITLE
Sonarqube 7.2 run_sonarqube.sh Error

### DIFF
--- a/root/opt/sonarqube/bin/run_sonarqube.sh
+++ b/root/opt/sonarqube/bin/run_sonarqube.sh
@@ -29,23 +29,26 @@ ln -s /opt/sonarqube/data/extensions /opt/sonarqube
 # Now make sure all plugins are in the plugins directory - this is especially
 # important after adding a PVC.
 # Sonarqube ships a selection of plugins in the /opt/sonarqube/lib/bundled-plugins directory.
-for plugin in /opt/sonarqube/lib/bundled-plugins/*
-do
+
+#For 7.2 this code does not work, lib/bundled-plugins was moved to extensions/plugins
+
+#for plugin in /opt/sonarqube/lib/bundled-plugins/*
+#do
   # Get the name of the plugin without any version number.
   # E.g. sonar-java-plugin instead of sonar-java-plugin-4.12.0.11033.jar
-  plugin_base_name=$(basename ${plugin%-*})
+  #plugin_base_name=$(basename ${plugin%-*})
 
   # For each plugin make sure it doesn't already exist in the data/extensions
   # directory. If it doesn't then copy it to the data/extensions directory.
-  echo "  ++++ checking if plugin ${plugin_base_name} is already installed"
-  if [ $(ls /opt/sonarqube/data/extensions/plugins/${plugin_base_name}* 2>/dev/null|wc -l) == 0 ];
-  then
-    echo "  ++++ Installing plugin ${plugin}..."
-    cp ${plugin} /opt/sonarqube/data/extensions/plugins
-  else
-    echo "  ++++ Plugin ${plugin_base_name} already installed."
-  fi
-done
+  #echo "  ++++ checking if plugin ${plugin_base_name} is already installed"
+  #if [ $(ls /opt/sonarqube/data/extensions/plugins/${plugin_base_name}* 2>/dev/null|wc -l) == 0 ];
+  #then
+    #echo "  ++++ Installing plugin ${plugin}..."
+    #cp ${plugin} /opt/sonarqube/data/extensions/plugins
+  #else
+    #echo "  ++++ Plugin ${plugin_base_name} already installed."
+  #fi
+#done
 echo "**** Setting up Data Volume complete"
 
 # Determine UID and GID under which the container is running


### PR DESCRIPTION
7.2 does not have lib/bundled-plugins, changed run_sonarqube.sh to reflect that, else errors when deploying in Openshift.

run_sonarqube.sh no longer needs to move the lib/bundled-plugins to the extensions folder.