### PR TITLE
Patch to Handle 7.2

### DIFF
--- a/root/opt/sonarqube/bin/run_sonarqube.sh
+++ b/root/opt/sonarqube/bin/run_sonarqube.sh
@@ -31,24 +31,29 @@ ln -s /opt/sonarqube/data/extensions /opt/sonarqube
 # Sonarqube ships a selection of plugins in the /opt/sonarqube/lib/bundled-plugins directory.
 
 #For 7.2 this code does not work, lib/bundled-plugins was moved to extensions/plugins
+if [ -d "/opt/sonarqube/lib/bundled-plugins" ];
+then
+  echo "**** Sonarqube Version < 7.2 Detected"
+  for plugin in /opt/sonarqube/lib/bundled-plugins/*
+  do
+    # Get the name of the plugin without any version number.
+    # E.g. sonar-java-plugin instead of sonar-java-plugin-4.12.0.11033.jar
+    plugin_base_name=$(basename ${plugin%-*})
 
-#for plugin in /opt/sonarqube/lib/bundled-plugins/*
-#do
-  # Get the name of the plugin without any version number.
-  # E.g. sonar-java-plugin instead of sonar-java-plugin-4.12.0.11033.jar
-  #plugin_base_name=$(basename ${plugin%-*})
-
-  # For each plugin make sure it doesn't already exist in the data/extensions
-  # directory. If it doesn't then copy it to the data/extensions directory.
-  #echo "  ++++ checking if plugin ${plugin_base_name} is already installed"
-  #if [ $(ls /opt/sonarqube/data/extensions/plugins/${plugin_base_name}* 2>/dev/null|wc -l) == 0 ];
-  #then
-    #echo "  ++++ Installing plugin ${plugin}..."
-    #cp ${plugin} /opt/sonarqube/data/extensions/plugins
-  #else
-    #echo "  ++++ Plugin ${plugin_base_name} already installed."
-  #fi
-#done
+    # For each plugin make sure it doesn't already exist in the data/extensions
+    # directory. If it doesn't then copy it to the data/extensions directory.
+    echo "  ++++ checking if plugin ${plugin_base_name} is already installed"
+    if [ $(ls /opt/sonarqube/data/extensions/plugins/${plugin_base_name}* 2>/dev/null|wc -l) == 0 ];
+    then
+      echo "  ++++ Installing plugin ${plugin}..."
+      cp ${plugin} /opt/sonarqube/data/extensions/plugins
+    else
+      echo "  ++++ Plugin ${plugin_base_name} already installed."
+    fi
+  done
+else
+  echo "**** Sonarqube Version > 7.2 Detected"
+fi
 echo "**** Setting up Data Volume complete"
 
 # Determine UID and GID under which the container is running

--- a/root/opt/sonarqube/bin/run_sonarqube.sh
+++ b/root/opt/sonarqube/bin/run_sonarqube.sh
@@ -26,34 +26,38 @@ else
 fi
 # Now link the extensions from the PVC into the expected location
 ln -s /opt/sonarqube/data/extensions /opt/sonarqube
-# Now make sure all plugins are in the plugins directory - this is especially
-# important after adding a PVC.
-# Sonarqube ships a selection of plugins in the /opt/sonarqube/lib/bundled-plugins directory.
 
-#For 7.2 this code does not work, lib/bundled-plugins was moved to extensions/plugins
+#Added for 7.2 this code does not work, lib/bundled-plugins was moved to extensions/plugins
+plugin_folder=""
 if [ -d "/opt/sonarqube/lib/bundled-plugins" ];
 then
   echo "**** Sonarqube Version < 7.2 Detected"
-  for plugin in /opt/sonarqube/lib/bundled-plugins/*
-  do
-    # Get the name of the plugin without any version number.
-    # E.g. sonar-java-plugin instead of sonar-java-plugin-4.12.0.11033.jar
-    plugin_base_name=$(basename ${plugin%-*})
-
-    # For each plugin make sure it doesn't already exist in the data/extensions
-    # directory. If it doesn't then copy it to the data/extensions directory.
-    echo "  ++++ checking if plugin ${plugin_base_name} is already installed"
-    if [ $(ls /opt/sonarqube/data/extensions/plugins/${plugin_base_name}* 2>/dev/null|wc -l) == 0 ];
-    then
-      echo "  ++++ Installing plugin ${plugin}..."
-      cp ${plugin} /opt/sonarqube/data/extensions/plugins
-    else
-      echo "  ++++ Plugin ${plugin_base_name} already installed."
-    fi
-  done
+  plugin_folder="/opt/sonarqube/lib/bundled-plugins/*"
 else
   echo "**** Sonarqube Version > 7.2 Detected"
+  plugin_folder="/opt/sonarqube/extensions/plugins/*"
 fi
+
+# Now make sure all plugins are in the plugins directory - this is especially
+# important after adding a PVC.
+# Sonarqube ships a selection of plugins in the /opt/sonarqube/lib/bundled-plugins directory.
+for plugin in $plugin_folder
+do
+  # Get the name of the plugin without any version number.
+  # E.g. sonar-java-plugin instead of sonar-java-plugin-4.12.0.11033.jar
+  plugin_base_name=$(basename ${plugin%-*})
+
+  # For each plugin make sure it doesn't already exist in the data/extensions
+  # directory. If it doesn't then copy it to the data/extensions directory.
+  echo "  ++++ checking if plugin ${plugin_base_name} is already installed"
+  if [ $(ls /opt/sonarqube/data/extensions/plugins/${plugin_base_name}* 2>/dev/null|wc -l) == 0 ];
+  then
+    echo "  ++++ Installing plugin ${plugin}..."
+    cp ${plugin} /opt/sonarqube/data/extensions/plugins
+  else
+    echo "  ++++ Plugin ${plugin_base_name} already installed."
+  fi
+done
 echo "**** Setting up Data Volume complete"
 
 # Determine UID and GID under which the container is running

--- a/root/opt/sonarqube/bin/run_sonarqube.sh
+++ b/root/opt/sonarqube/bin/run_sonarqube.sh
@@ -29,23 +29,26 @@ ln -s /opt/sonarqube/data/extensions /opt/sonarqube
 # Now make sure all plugins are in the plugins directory - this is especially
 # important after adding a PVC.
 # Sonarqube ships a selection of plugins in the /opt/sonarqube/lib/bundled-plugins directory.
-for plugin in /opt/sonarqube/lib/bundled-plugins/*
-do
+
+#For 7.2 this code does not work, lib/bundled-plugins was moved to extensions/plugins
+
+#for plugin in /opt/sonarqube/lib/bundled-plugins/*
+#do
   # Get the name of the plugin without any version number.
   # E.g. sonar-java-plugin instead of sonar-java-plugin-4.12.0.11033.jar
-  plugin_base_name=$(basename ${plugin%-*})
+  #plugin_base_name=$(basename ${plugin%-*})
 
   # For each plugin make sure it doesn't already exist in the data/extensions
   # directory. If it doesn't then copy it to the data/extensions directory.
-  echo "  ++++ checking if plugin ${plugin_base_name} is already installed"
-  if [ $(ls /opt/sonarqube/data/extensions/plugins/${plugin_base_name}* 2>/dev/null|wc -l) == 0 ];
-  then
-    echo "  ++++ Installing plugin ${plugin}..."
-    cp ${plugin} /opt/sonarqube/data/extensions/plugins
-  else
-    echo "  ++++ Plugin ${plugin_base_name} already installed."
-  fi
-done
+  #echo "  ++++ checking if plugin ${plugin_base_name} is already installed"
+  #if [ $(ls /opt/sonarqube/data/extensions/plugins/${plugin_base_name}* 2>/dev/null|wc -l) == 0 ];
+  #then
+    #echo "  ++++ Installing plugin ${plugin}..."
+    #cp ${plugin} /opt/sonarqube/data/extensions/plugins
+  #else
+    #echo "  ++++ Plugin ${plugin_base_name} already installed."
+  #fi
+#done
 echo "**** Setting up Data Volume complete"
 
 # Determine UID and GID under which the container is running


### PR DESCRIPTION
Added more code to handle the new folder structure of bundled-plugins as this structure changed in Sonarqube 7.2.

@wkulhanek I tested this new code to ensure that the deployment works. Tested it on 6.7.4 and 7.2 and it worked on my minishift. As for the code logic, I did not test. Based on my logic written, I believe it will work because it only changes where the bundled-plugin resides based on the version. Your original code remains untouched. Please let me know if it makes sense to you.